### PR TITLE
abort when nested (bugfix)

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -36,7 +36,7 @@ if(CPM_DIRECTORY)
       message(AUTHOR_WARNING "${CPM_INDENT} \
 A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
 It is recommended to upgrade CPM to the most recent version. \
-See https://github.com/TheLartians/CPM for more information."
+See https://github.com/TheLartians/CPM.cmake for more information."
       )
     endif()
     return()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -28,7 +28,7 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-set(CURRENT_CPM_VERSION 0.15) 
+set(CURRENT_CPM_VERSION 0.15.1)
 
 if(CPM_DIRECTORY)
   if(NOT ${CPM_DIRECTORY} MATCHES ${CMAKE_CURRENT_LIST_DIR})
@@ -39,6 +39,7 @@ It is recommended to upgrade CPM to the most recent version. \
 See https://github.com/TheLartians/CPM for more information."
       )
     endif()
+    return()
   endif()
 endif()
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -34,7 +34,7 @@ if(CPM_DIRECTORY)
   if(NOT ${CPM_DIRECTORY} MATCHES ${CMAKE_CURRENT_LIST_DIR})
     if (${CPM_VERSION} VERSION_LESS ${CURRENT_CPM_VERSION})
       message(AUTHOR_WARNING "${CPM_INDENT} \
-A dependency is using a more recent CPM (${NEW_CPM_VERSION}) than the current project (${CPM_VERSION}). \
+A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
 It is recommended to upgrade CPM to the most recent version. \
 See https://github.com/TheLartians/CPM for more information."
       )


### PR DESCRIPTION
Fixes a bug introduced in the last update that broke configuration when a nested dependency has a newer CPM version than the outer project.