### PR TITLE
Add package lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Dependencies using CPM will automatically use the updated script of the outermos
 
 - **Small and reusable projects** CPM takes care of all project dependencies, allowing developers to focus on creating small, well-tested libraries.
 - **Cross-Platform** CPM adds projects directly at the configure stage and is compatible with all CMake toolchains and generators.
-- **Reproducable builds** By versioning dependencies via git commits or tags it is ensured that a project will always be buildable.
+- **Reproducible builds** By versioning dependencies via git commits or tags it is ensured that a project will always be buildable.
 - **Recursive dependencies** Ensures that no dependency is added twice and all are added in the minimum required version.
 - **Plug-and-play** No need to install anything. Just add the script to your project and you're good to go.
 - **No packaging required** Simply add all external sources as a dependency.
@@ -105,7 +105,7 @@ Dependencies using CPM will automatically use the updated script of the outermos
 
 - **No pre-built binaries** For every new build directory, all dependencies are initially downloaded and built from scratch. To avoid extra downloads it is recommend to set the [`CPM_SOURCE_CACHE`](#CPM_SOURCE_CACHE) environmental variable. Using a caching compiler such as [ccache](https://github.com/TheLartians/Ccache.cmake) can drastically reduce build time.
 - **Dependent on good CMakeLists** Many libraries do not have CMakeLists that work well for subprojects. Luckily this is slowly changing, however, until then, some manual configuration may be required (see the snippets [below](#snippets) for examples). For best practices on preparing projects for CPM, see the [wiki](https://github.com/TheLartians/CPM.cmake/wiki/Preparing-projects-for-CPM.cmake). 
-- **First version used** In diamond-shaped dependency graphs (e.g. `A` depends on `C`@1.1 and `B`, which itself depends on `C`@1.2 the first added dependency will be used (in this case `C`@1.1). In this case, B requires a newer version of `C` than `A`, so CPM will emit a warning. This can be resolved by adding a new version of the dependency in the outermost project.
+- **First version used** In diamond-shaped dependency graphs (e.g. `A` depends on `C`@1.1 and `B`, which itself depends on `C`@1.2 the first added dependency will be used (in this case `C`@1.1). In this case, B requires a newer version of `C` than `A`, so CPM will emit a warning. This can be easily resolved by adding a new version of the dependency in the outermost project, or by introducing a [package lock file](https://github.com/TheLartians/CPM.cmake/wiki/Package-lock).
 
 For projects with more complex needs and where an extra setup step doesn't matter, it may be worth to check out an external C++ package manager such as [vcpkg](https://github.com/microsoft/vcpkg), [conan](https://conan.io) or [hunter](https://github.com/ruslo/hunter).
 Dependencies added with `CPMFindPackage` should work with external package managers.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -217,11 +217,11 @@ function(CPMAddPackage)
   endif()
 
   if (CPM_ARGS_GITHUB_REPOSITORY)
-    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_REPOSITORY "https://github.com/${CPM_ARGS_GITHUB_REPOSITORY}.git")
+    set(CPM_ARGS_GIT_REPOSITORY "https://github.com/${CPM_ARGS_GITHUB_REPOSITORY}.git")
   endif()
 
   if (CPM_ARGS_GITLAB_REPOSITORY)
-    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
+    list(CPM_ARGS_GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
   endif()
 
   if (DEFINED CPM_ARGS_GIT_REPOSITORY)
@@ -244,7 +244,6 @@ function(CPMAddPackage)
 
   # Check for available declaration
   if (DEFINED "CPM_DECLARATION_${CPM_ARGS_NAME}" AND NOT "${CPM_DECLARATION_${CPM_ARGS_NAME}}" STREQUAL "")
-    message("is declared: ${CPM_DECLARATION_${CPM_ARGS_NAME}}")
     set(declaration ${CPM_DECLARATION_${CPM_ARGS_NAME}})
     set(CPM_DECLARATION_${CPM_ARGS_NAME} "")
     CPMAddPackage(${declaration})
@@ -276,8 +275,6 @@ function(CPMAddPackage)
       set(${OPTION_KEY} ${OPTION_VALUE} CACHE INTERNAL "")
     endforeach()
   endif()
-
-  set(CPM_ARGS_UNPARSED_ARGUMENTS "")
 
   if (DEFINED CPM_ARGS_GIT_TAG)
     set(PACKAGE_INFO "${CPM_ARGS_GIT_TAG}")
@@ -311,7 +308,9 @@ function(CPMAddPackage)
   cpm_fetch_package(${CPM_ARGS_NAME} ${DOWNLOAD_ONLY})
   cpm_get_fetch_properties(${CPM_ARGS_NAME})
   CPMCreateModuleFile(${CPM_ARGS_NAME} "CPMAddPackage(${ARGN})")
-  cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
+  if (TARGET cpm-update-package-lock)
+    cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
+  endif()
   SET(${CPM_ARGS_NAME}_ADDED YES)
   cpm_export_variables(${CPM_ARGS_NAME})
 endfunction()
@@ -329,7 +328,6 @@ endmacro()
 macro(CPMDeclarePackage Name)
   if (NOT DEFINED "CPM_DECLARATION_${CPM_ARGS_NAME}")
     set("CPM_DECLARATION_${Name}" "${ARGN}")
-    message("declare: CPM_DECLARATION_${Name}: ${CPM_DECLARATION_${Name}}")
   endif()
 endmacro()
 
@@ -368,9 +366,6 @@ endfunction()
 # declares a package in FetchContent_Declare 
 function (cpm_declare_fetch PACKAGE VERSION INFO)
   message(STATUS "${CPM_INDENT} adding package ${PACKAGE}@${VERSION} (${INFO})")
-  message("test: FetchContent_Declare(${PACKAGE}
-  ${ARGN}
-)")
 
   if (${CPM_DRY_RUN}) 
     message(STATUS "${CPM_INDENT} package not declared (dry run)")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -315,6 +315,17 @@ function(CPMAddPackage)
   cpm_export_variables(${CPM_ARGS_NAME})
 endfunction()
 
+# Fetch a previously declared package
+macro(CPMGetPackage Name)
+  if (DEFINED "CPM_DECLARATION_${Name}")
+    CPMAddPackage(
+      NAME ${Name}
+    )
+  else()
+    message(SEND_ERROR "Cannot retrieve package ${Name}: no declaration available")
+  endif()
+endmacro()
+
 # export variables available to the caller to the parent scope
 # expects ${CPM_ARGS_NAME} to be set
 macro(cpm_export_variables name)
@@ -326,7 +337,7 @@ endmacro()
 # declares a package, so that any call to CPMAddPackage for the 
 # package name will use these arguments instead 
 macro(CPMDeclarePackage Name)
-  if (NOT DEFINED "CPM_DECLARATION_${CPM_ARGS_NAME}")
+  if (NOT DEFINED "CPM_DECLARATION_${Name}")
     set("CPM_DECLARATION_${Name}" "${ARGN}")
   endif()
 endmacro()

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -81,7 +81,7 @@ endif()
 
 if (NOT CPM_DONT_CREATE_PACKAGE_LOCK)
   set(CPM_PACKAGE_LOCK_FILE "${CMAKE_BINARY_DIR}/cpm-package-lock.cmake" CACHE INTERNAL "")
-  file(WRITE ${CPM_PACKAGE_LOCK_FILE} "# CPM Package Lock\n\n")
+  file(WRITE ${CPM_PACKAGE_LOCK_FILE} "# CPM Package Lock\n# This file should be committed to version control\n\n")
 endif()
 
 include(FetchContent)
@@ -329,7 +329,7 @@ function(cpm_add_to_package_lock Name)
   endif()
 endfunction()
 
-# includes the package lock file, if it exists, and creates a target
+# includes the package lock file if it exists and creates a target
 # `cpm-write-package-lock` to update it
 macro(CPMUsePackageLock file)
   if (NOT CPM_DONT_CREATE_PACKAGE_LOCK)
@@ -337,13 +337,13 @@ macro(CPMUsePackageLock file)
     if(EXISTS ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
       include(${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
     endif()
-    if (NOT TARGET cpm-write-package-lock)
-      add_custom_target(cpm-write-package-lock COMMAND ${CMAKE_COMMAND} -E copy ${CPM_PACKAGE_LOCK_FILE} ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
+    if (NOT TARGET cpm-update-package-lock)
+      add_custom_target(cpm-update-package-lock COMMAND ${CMAKE_COMMAND} -E copy ${CPM_PACKAGE_LOCK_FILE} ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
     endif()
   endif()
 endmacro()
 
-# registers a package has been added to CPM
+# registers a package that has been added to CPM
 function(CPMRegisterPackage PACKAGE VERSION)
   list(APPEND CPM_PACKAGES ${PACKAGE})
   set(CPM_PACKAGES ${CPM_PACKAGES} CACHE INTERNAL "")

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -310,9 +310,9 @@ endfunction()
 # export variables available to the caller to the parent scope
 # expects ${CPM_ARGS_NAME} to be set
 macro(cpm_export_variables name)
-  SET(${name}_SOURCE_DIR "${${CPM_ARGS_NAME}_SOURCE_DIR}" PARENT_SCOPE)
-  SET(${name}_BINARY_DIR "${${CPM_ARGS_NAME}_BINARY_DIR}" PARENT_SCOPE)
-  SET(${name}_ADDED "${${CPM_ARGS_NAME}_ADDED}" PARENT_SCOPE)
+  SET(${name}_SOURCE_DIR "${${name}_SOURCE_DIR}" PARENT_SCOPE)
+  SET(${name}_BINARY_DIR "${${name}_BINARY_DIR}" PARENT_SCOPE)
+  SET(${name}_ADDED "${${name}_ADDED}" PARENT_SCOPE)
 endmacro()
 
 # declares a package, so that any call to CPMAddPackage for the 

--- a/test/unit/modules.cmake
+++ b/test/unit/modules.cmake
@@ -6,7 +6,7 @@ set(TEST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
 function(initProjectWithDependency TEST_DEPENDENCY_NAME)
   configure_package_config_file(
-    "${CMAKE_CURRENT_LIST_DIR}/test_project/CMakeLists.txt.in"
+    "${CMAKE_CURRENT_LIST_DIR}/test_project/ModuleCMakeLists.txt.in"
     "${CMAKE_CURRENT_LIST_DIR}/test_project/CMakeLists.txt"
     INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/junk
   )

--- a/test/unit/package-lock.cmake
+++ b/test/unit/package-lock.cmake
@@ -1,0 +1,48 @@
+
+include(CMakePackageConfigHelpers)
+include(${CPM_PATH}/testing.cmake)
+
+set(TEST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/package-lock)
+
+function(configureWithDeclare DECLARE_DEPENDENCY)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf ${TEST_BUILD_DIR})
+
+  if (DECLARE_DEPENDENCY)
+    set(PREPARE_CODE "CPMDeclarePackage(Dependency
+      NAME Dependency 
+      SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/test_project/dependency
+    )")
+  else()
+    set(PREPARE_CODE "")
+  endif()
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/test_project/PackageLockCMakeLists.txt.in"
+    "${CMAKE_CURRENT_LIST_DIR}/test_project/CMakeLists.txt"
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/junk
+  )
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -H${CMAKE_CURRENT_LIST_DIR}/test_project -B${TEST_BUILD_DIR}
+    RESULT_VARIABLE ret
+  )
+
+  ASSERT_EQUAL(${ret} "0")
+endfunction()
+
+function(updatePackageLock)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --build ${TEST_BUILD_DIR} --target cpm-update-package-lock
+    RESULT_VARIABLE ret
+  )
+
+  ASSERT_EQUAL(${ret} "0")
+endfunction()
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E rm -f ${CMAKE_CURRENT_LIST_DIR}/test_project/package-lock.cmake)
+configureWithDeclare(YES)
+ASSERT_NOT_EXISTS(${CMAKE_CURRENT_LIST_DIR}/test_project/package-lock.cmake)
+updatePackageLock()
+ASSERT_EXISTS(${CMAKE_CURRENT_LIST_DIR}/test_project/package-lock.cmake)
+configureWithDeclare(NO)
+

--- a/test/unit/source_dir.cmake
+++ b/test/unit/source_dir.cmake
@@ -7,7 +7,7 @@ set(TEST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/source_dir)
 set(TEST_DEPENDENCY_NAME Dependency)
 
 configure_package_config_file(
-  "${CMAKE_CURRENT_LIST_DIR}/test_project/CMakeLists.txt.in"
+  "${CMAKE_CURRENT_LIST_DIR}/test_project/ModuleCMakeLists.txt.in"
   "${CMAKE_CURRENT_LIST_DIR}/test_project/CMakeLists.txt"
   INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/junk
 )

--- a/test/unit/test_project/.gitignore
+++ b/test/unit/test_project/.gitignore
@@ -1,1 +1,2 @@
 /CMakeLists.txt
+/package-lock.cmake

--- a/test/unit/test_project/ModuleCMakeLists.txt.in
+++ b/test/unit/test_project/ModuleCMakeLists.txt.in
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(CPMTest)
+
+# ---- Options ----
+
+option(ENABLE_TEST_COVERAGE "Enable test coverage" OFF)
+
+# ---- Dependencies ----
+
+include(@CPM_PATH@/CPM.cmake)
+
+CPMAddPackage(
+  NAME @TEST_DEPENDENCY_NAME@
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/dependency
+)
+
+# ---- check if generated modules override find_package ----
+
+if (@test_check_find_package@)
+  find_package(@TEST_DEPENDENCY_NAME@ REQUIRED)
+endif()
+
+# ---- Call dependency method to validate correct addition of directory ----
+
+dependency_function()

--- a/test/unit/test_project/PackageLockCMakeLists.txt.in
+++ b/test/unit/test_project/PackageLockCMakeLists.txt.in
@@ -13,9 +13,7 @@ CPMUsePackageLock(package-lock.cmake)
 
 @PREPARE_CODE@
 
-CPMAddPackage(
-  NAME Dependency
-)
+CPMGetPackage(Dependency)
 
 # ---- Call dependency method to validate correct addition of directory ----
 

--- a/test/unit/test_project/PackageLockCMakeLists.txt.in
+++ b/test/unit/test_project/PackageLockCMakeLists.txt.in
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(CPMExampleCatch2)
+project(CPMTest)
 
 # ---- Options ----
 
@@ -9,17 +9,13 @@ option(ENABLE_TEST_COVERAGE "Enable test coverage" OFF)
 # ---- Dependencies ----
 
 include(@CPM_PATH@/CPM.cmake)
+CPMUsePackageLock(package-lock.cmake)
+
+@PREPARE_CODE@
 
 CPMAddPackage(
-  NAME @TEST_DEPENDENCY_NAME@
-  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/dependency
+  NAME Dependency
 )
-
-# ---- check if generated modules override find_package ----
-
-if (@test_check_find_package@)
-  find_package(@TEST_DEPENDENCY_NAME@ REQUIRED)
-endif()
 
 # ---- Call dependency method to validate correct addition of directory ----
 

--- a/test/unit/test_project/package-lock.cmake
+++ b/test/unit/test_project/package-lock.cmake
@@ -1,5 +1,0 @@
-# CPM Package Lock
-# This file should be committed to version control
-
-# Dependency
-CPMDeclarePackage(Dependency "NAME;Dependency;SOURCE_DIR;/Users/lars/Documents/Development/CPM/test/unit/test_project/dependency")

--- a/test/unit/test_project/package-lock.cmake
+++ b/test/unit/test_project/package-lock.cmake
@@ -1,0 +1,5 @@
+# CPM Package Lock
+# This file should be committed to version control
+
+# Dependency
+CPMDeclarePackage(Dependency "NAME;Dependency;SOURCE_DIR;/Users/lars/Documents/Development/CPM/test/unit/test_project/dependency")


### PR DESCRIPTION
The package lock makes it easier to override transitive dependencies and is a first step towards #99.

## Usage

After including CPM.cmake, call `CPMUsePackageLock(package-lock.cmake)` to include `package-lock.cmake`, if it exists. This file can be created and updated using the target `cpm-update-package-lock`. Note that it should be added to version control.


## TODO

- [x] implement package-lock
- [x] add tests
- [x] add documentation
