### PR TITLE
Fix indeterminate command for GitLab argument

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -219,7 +219,7 @@ function(CPMAddPackage)
   endif()
 
   if (DEFINED CPM_ARGS_GITLAB_REPOSITORY)
-    list(CPM_ARGS_GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
+    set(CPM_ARGS_GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
   endif()
 
   if (DEFINED CPM_ARGS_GIT_REPOSITORY)


### PR DESCRIPTION
The intended behavior to capture the GitLab argument is better accomplished using `set` rather than `list` as with the GitHub argument above. In addition, there is no documented form of the `list` command with that format.