### PR TITLE
ignore lua.c and luac.c from lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ if (lua_ADDED)
   # lua has no CMake support, so we create our own target
 
   FILE(GLOB lua_sources ${lua_SOURCE_DIR}/*.c)
+  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c")
+  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/luac.c")
   add_library(lua STATIC ${lua_sources})
 
   target_include_directories(lua

--- a/README.md
+++ b/README.md
@@ -351,8 +351,7 @@ if (lua_ADDED)
   # lua has no CMake support, so we create our own target
 
   FILE(GLOB lua_sources ${lua_SOURCE_DIR}/*.c)
-  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c")
-  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/luac.c")
+  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c" "${lua_SOURCE_DIR}/luac.c")
   add_library(lua STATIC ${lua_sources})
 
   target_include_directories(lua

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -17,6 +17,7 @@ if (lua_ADDED)
   # lua has no CMakeLists, so we create our own target
 
   FILE(GLOB lua_sources ${lua_SOURCE_DIR}/*.c)
+  list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c" "${lua_SOURCE_DIR}/luac.c")
   add_library(lua STATIC ${lua_sources})
 
   target_include_directories(lua


### PR DESCRIPTION
When link you might get errors saying there is winMain (when WIN32 is enabled) and main and compiler will pick main so. Remove lua.c and luac.c so winMain is picked up by default when linking.