### PR TITLE
fix passing options when using CPM_<pkg>_SOURCE

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -252,6 +252,7 @@ function(CPMAddPackage)
       NAME ${CPM_ARGS_NAME}
       SOURCE_DIR ${PACKAGE_SOURCE}
       FORCE True
+      OPTIONS ${CPM_ARGS_OPTIONS}
     )
     cpm_export_variables(${CPM_ARGS_NAME})
     return()


### PR DESCRIPTION
When I used CPM_<pkg>_SOURCE to point to a locally modified copy, the `OPTIONS` ended up not being passed on. I think they should be, so this patch does pass them to the repeated `CPMAddPackage()`.