### PR TITLE
fix: GIT_TAG not parsed inside CPMFindPackage

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -119,6 +119,7 @@ function(CPMFindPackage)
   set(oneValueArgs
     NAME
     VERSION
+    GIT_TAG
     FIND_PACKAGE_ARGUMENTS
   )
 


### PR DESCRIPTION
When using CPMFindPackage, if no VERSION is given then GIT_TAG is used as fallback if defined, which is a good idea.
The issue is that GIT_TAG is missing inside the oneValueArgs variable therefore GIT_TAG is not parsed. This is resolved by this little change.