### PR TITLE
Expand CPM_SOURCE_CACHE path provided as a configure argument

### DIFF
--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -1,6 +1,8 @@
 set(CPM_DOWNLOAD_VERSION 1.0.0-development-version)
 
 if(CPM_SOURCE_CACHE)
+  # Expand relative path. This is important if the provided path contains a tilde (~)
+  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")


### PR DESCRIPTION
Long story:

If one relies on `get_cpm.cmake` instead of a manual copy of CPM.cmake, and configures with `-DCPM_SOURCE_CACHE=~/some/path` (with a tilde which they expect to be expanded to $HOME), [this CMake issue hits](https://gitlab.kitware.com/cmake/cmake/-/issues/21729) and thus the `EXISTS` check always fails, and `file(DOWNLOAD` always fails (one would expect that it would create the directory `\~` (literal tilde) but it doesn't... anyway)

Further when CPM.cmake gets included `CPM_SOURCE_CACHE` is cached as `CACHE PATH` which does the expansion and subsequent code is not affected by the tilde. That's why nothing special needs to be done for the actual CPM.cmake code. It works even if used by a manual copy and not through get_cpm.