### PR TITLE
update most package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 /build*
 /.vscode
 *.DS_Store

--- a/examples/asio-standalone/CMakeLists.txt
+++ b/examples/asio-standalone/CMakeLists.txt
@@ -24,7 +24,7 @@ CPMAddPackage(
 if(asio_ADDED)
   add_library(asio INTERFACE)
 
-  target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
+  target_include_directories(asio SYSTEM INTERFACE ${asio_SOURCE_DIR}/asio/include)
 
   target_compile_definitions(asio INTERFACE ASIO_STANDALONE ASIO_NO_DEPRECATED)
 
@@ -65,4 +65,4 @@ endif()
 
 add_executable(CPMExampleASIOStandalone main.cpp)
 target_link_libraries(CPMExampleASIOStandalone asio)
-target_compile_features(CPMExampleASIOStandalone PRIVATE cxx_std_20)
+target_compile_features(CPMExampleASIOStandalone PRIVATE cxx_std_17)

--- a/examples/asio-standalone/CMakeLists.txt
+++ b/examples/asio-standalone/CMakeLists.txt
@@ -10,9 +10,9 @@ find_package(Threads REQUIRED)
 
 CPMAddPackage(
   NAME asio
-  VERSION 1.16.1
+  VERSION 1.18.1
   GITHUB_REPOSITORY chriskohlhoff/asio
-  GIT_TAG asio-1-16-1 # asio uses non-standard version tag, we must specify GIT_TAG
+  GIT_TAG asio-1-18-1 # asio uses non-standard version tag, we must specify GIT_TAG
 )
 
 # ASIO doesn't use CMake, we have to configure it manually. Extra notes for using on Windows:
@@ -65,3 +65,4 @@ endif()
 
 add_executable(CPMExampleASIOStandalone main.cpp)
 target_link_libraries(CPMExampleASIOStandalone asio)
+target_compile_features(CPMExampleASIOStandalone PRIVATE cxx_std_20)

--- a/examples/asio-standalone/CMakeLists.txt
+++ b/examples/asio-standalone/CMakeLists.txt
@@ -65,4 +65,4 @@ endif()
 
 add_executable(CPMExampleASIOStandalone main.cpp)
 target_link_libraries(CPMExampleASIOStandalone asio)
-target_compile_features(CPMExampleASIOStandalone PRIVATE cxx_std_17)
+target_compile_features(CPMExampleASIOStandalone PRIVATE cxx_std_11)

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -15,13 +15,13 @@ CPMAddPackage(
 CPMAddPackage(
   NAME benchmark
   GITHUB_REPOSITORY google/benchmark
-  VERSION 1.5.0
+  VERSION 1.5.2
   OPTIONS "BENCHMARK_ENABLE_TESTING Off"
 )
 
 if(benchmark_ADDED)
-  # patch google benchmark target
-  set_target_properties(benchmark PROPERTIES CXX_STANDARD 17)
+  # Don't use C++14 because it doesn't work in some configurations.
+  set_target_properties(benchmark PROPERTIES CXX_STANDARD 11)
 endif()
 
 # ---- Executable ----

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -27,5 +27,5 @@ endif()
 # ---- Executable ----
 
 add_executable(CPMExampleBenchmark "main.cpp")
-set_target_properties(CPMExampleBenchmark PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMExampleBenchmark fibonacci benchmark)
+target_compile_features(CPMExampleBenchmark PRIVATE cxx_std_17)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -5,7 +5,7 @@ project(CPMExampleBoost)
 # ---- Create binary ----
 
 add_executable(CPMExampleBoost main.cpp)
-set_target_properties(CPMExampleBoost PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleBoost PRIVATE cxx_std_20)
 
 # ---- Dependencies ----
 
@@ -14,8 +14,10 @@ include(../../cmake/CPM.cmake)
 CPMFindPackage(
   NAME Boost
   GITHUB_REPOSITORY Orphis/boost-cmake
-  VERSION 1.67.0
+  VERSION 1.71.0
   FIND_PACKAGE_ARGUMENTS "COMPONENTS system"
 )
 
-target_link_libraries(CPMExampleBoost PRIVATE Boost::system pthread)
+find_package(Threads REQUIRED)
+
+target_link_libraries(CPMExampleBoost PRIVATE Boost::system Threads::Threads)

--- a/examples/boost/CMakeLists.txt
+++ b/examples/boost/CMakeLists.txt
@@ -5,7 +5,7 @@ project(CPMExampleBoost)
 # ---- Create binary ----
 
 add_executable(CPMExampleBoost main.cpp)
-target_compile_features(CPMExampleBoost PRIVATE cxx_std_20)
+target_compile_features(CPMExampleBoost PRIVATE cxx_std_17)
 
 # ---- Dependencies ----
 
@@ -14,7 +14,7 @@ include(../../cmake/CPM.cmake)
 CPMFindPackage(
   NAME Boost
   GITHUB_REPOSITORY Orphis/boost-cmake
-  VERSION 1.71.0
+  VERSION 1.67.0
   FIND_PACKAGE_ARGUMENTS "COMPONENTS system"
 )
 

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -7,7 +7,7 @@ from subprocess import PIPE, run
 
 # NOTE: boost V1.67 is to old! CK
 examples = [
-    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost'])
+    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost', 'old-gtest'])
 ]
 
 assert(len(examples) > 0)
@@ -37,8 +37,9 @@ for example in examples:
         before = "-DCMAKE_PROJECT_INCLUDE_BEFORE=%s/before_project_setup.cmake" % (
             cmakeModulesPath)
         after = "-DCMAKE_PROJECT_INCLUDE=%s/build_options.cmake" % (cmakeModulesPath)
-
-    configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
+        configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
+    else:
+        configure = runCommand('cmake -H%s -B%s' % (example, project))
     print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
     build = runCommand('cmake --build %s -j8' % (project))
     print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -5,9 +5,8 @@ import os
 from pathlib import Path
 from subprocess import PIPE, run
 
-# NOTE: boost V1.67 is to old! CK
 examples = [
-  x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost'])
+  x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists()
 ]
 
 assert(len(examples) > 0)

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -7,7 +7,7 @@ from subprocess import PIPE, run
 
 # NOTE: boost V1.67 is to old! CK
 examples = [
-    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost', 'old-gtest'])
+  x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost'])
 ]
 
 assert(len(examples) > 0)
@@ -27,18 +27,8 @@ for example in examples:
   print("running example %s" % example.name)
   print("================" + ('=' * len(example.name)))
   project = Path(".") / 'build' / example.name
-  #
-  # Note: needs at least cmake V3.15! CK
-  # https://cmake.org/cmake/help/latest/command/project.html#code-injection
-  #
-  cmakeModulesPath = os.environ['HOME'] + '/Workspace/cmake'
-  if Path(cmakeModulesPath).is_dir():
-    before = "-DCMAKE_PROJECT_INCLUDE_BEFORE=%s/before_project_setup.cmake" % (cmakeModulesPath)
-    after = "-DCMAKE_PROJECT_INCLUDE=%s/build_options.cmake" % (cmakeModulesPath)
-    configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
-  else:
-    configure = runCommand('cmake -H%s -B%s' % (example, project))
+  configure = runCommand('cmake -H%s -B%s' % (example, project))
   print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
-  build = runCommand('cmake --build %s -j%i' % (project, os.cpu_count()))
+  build = runCommand('cmake --build %s -- -j%i' % (project, os.cpu_count() / 2))
   print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
   print('')

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -1,29 +1,38 @@
 #!/usr/bin/python3
 
+import os
+
 from pathlib import Path
 from subprocess import PIPE, run
 
 examples = [
-  x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists()
+    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (x.name != 'benchmark')
 ]
 
 assert(len(examples) > 0)
 
+
 def runCommand(command):
-  print('- %s' % command)
-  result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
-  if result.returncode != 0:
-    print("error while running '%s':\n" % command, '  ' + str(result.stderr).replace('\n','\n  '))
-    exit(result.returncode)
-  return result.stdout
+    print('- %s' % command)
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
+    if result.returncode != 0:
+        print("error while running '%s':\n" %
+              command, '  ' + str(result.stderr).replace('\n', '\n  '))
+        exit(result.returncode)
+    return result.stdout
+
 
 print('')
 for example in examples:
-  print("running example %s" % example.name)
-  print("================" + ('=' * len(example.name)))
-  project = Path(".") / 'build' / example.name
-  configure = runCommand('cmake -H%s -B%s' % (example, project))
-  print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
-  build = runCommand('cmake --build %s -j4' % (project))
-  print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
-  print('')
+    print("running example %s" % example.name)
+    print("================" + ('=' * len(example.name)))
+    project = Path(".") / 'build' / example.name
+    cmakeModulesPath = os.environ['HOME'] + '/Workspace/cmake'
+    before = "%s/before_project_setup.cmake" % (cmakeModulesPath)
+    after = "%s/build_options.cmake" % (cmakeModulesPath)
+    configure = runCommand(
+        'cmake -H%s -B%s -G Ninja -DCMAKE_PROJECT_INCLUDE_BEFORE=%s -DCMAKE_PROJECT_INCLUDE=%s' % (example, project, before, after))
+    print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
+    build = runCommand('cmake --build %s -j8' % (project))
+    print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
+    print('')

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -41,6 +41,6 @@ for example in examples:
     else:
         configure = runCommand('cmake -H%s -B%s' % (example, project))
     print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
-    build = runCommand('cmake --build %s -j8' % (project))
+    build = runCommand('cmake --build %s -j%i' % (project, os.cpu_count()))
     print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
     print('')

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -5,8 +5,9 @@ import os
 from pathlib import Path
 from subprocess import PIPE, run
 
+# NOTE: boost V1.67 is to old! CK
 examples = [
-    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (x.name != 'benchmark')
+    x for x in Path(__file__).parent.iterdir() if x.is_dir() and (x / 'CMakeLists.txt').exists() and (not x.name in ['boost'])
 ]
 
 assert(len(examples) > 0)
@@ -27,11 +28,17 @@ for example in examples:
     print("running example %s" % example.name)
     print("================" + ('=' * len(example.name)))
     project = Path(".") / 'build' / example.name
+    #
+    # Note: needs at least cmake V3.15! CK
+    # https://cmake.org/cmake/help/latest/command/project.html#code-injection
+    #
     cmakeModulesPath = os.environ['HOME'] + '/Workspace/cmake'
-    before = "%s/before_project_setup.cmake" % (cmakeModulesPath)
-    after = "%s/build_options.cmake" % (cmakeModulesPath)
-    configure = runCommand(
-        'cmake -H%s -B%s -G Ninja -DCMAKE_PROJECT_INCLUDE_BEFORE=%s -DCMAKE_PROJECT_INCLUDE=%s' % (example, project, before, after))
+    if Path(cmakeModulesPath).is_dir():
+        before = "-DCMAKE_PROJECT_INCLUDE_BEFORE=%s/before_project_setup.cmake" % (
+            cmakeModulesPath)
+        after = "-DCMAKE_PROJECT_INCLUDE=%s/build_options.cmake" % (cmakeModulesPath)
+
+    configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
     print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
     build = runCommand('cmake --build %s -j8' % (project))
     print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))

--- a/examples/build_all.py
+++ b/examples/build_all.py
@@ -14,33 +14,31 @@ assert(len(examples) > 0)
 
 
 def runCommand(command):
-    print('- %s' % command)
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
-    if result.returncode != 0:
-        print("error while running '%s':\n" %
-              command, '  ' + str(result.stderr).replace('\n', '\n  '))
-        exit(result.returncode)
-    return result.stdout
+  print('- %s' % command)
+  result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
+  if result.returncode != 0:
+    print("error while running '%s':\n" % command, '  ' + str(result.stderr).replace('\n', '\n  '))
+    exit(result.returncode)
+  return result.stdout
 
 
 print('')
 for example in examples:
-    print("running example %s" % example.name)
-    print("================" + ('=' * len(example.name)))
-    project = Path(".") / 'build' / example.name
-    #
-    # Note: needs at least cmake V3.15! CK
-    # https://cmake.org/cmake/help/latest/command/project.html#code-injection
-    #
-    cmakeModulesPath = os.environ['HOME'] + '/Workspace/cmake'
-    if Path(cmakeModulesPath).is_dir():
-        before = "-DCMAKE_PROJECT_INCLUDE_BEFORE=%s/before_project_setup.cmake" % (
-            cmakeModulesPath)
-        after = "-DCMAKE_PROJECT_INCLUDE=%s/build_options.cmake" % (cmakeModulesPath)
-        configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
-    else:
-        configure = runCommand('cmake -H%s -B%s' % (example, project))
-    print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
-    build = runCommand('cmake --build %s -j%i' % (project, os.cpu_count()))
-    print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
-    print('')
+  print("running example %s" % example.name)
+  print("================" + ('=' * len(example.name)))
+  project = Path(".") / 'build' / example.name
+  #
+  # Note: needs at least cmake V3.15! CK
+  # https://cmake.org/cmake/help/latest/command/project.html#code-injection
+  #
+  cmakeModulesPath = os.environ['HOME'] + '/Workspace/cmake'
+  if Path(cmakeModulesPath).is_dir():
+    before = "-DCMAKE_PROJECT_INCLUDE_BEFORE=%s/before_project_setup.cmake" % (cmakeModulesPath)
+    after = "-DCMAKE_PROJECT_INCLUDE=%s/build_options.cmake" % (cmakeModulesPath)
+    configure = runCommand('cmake -H%s -B%s -G Ninja %s %s' % (example, project, before, after))
+  else:
+    configure = runCommand('cmake -H%s -B%s' % (example, project))
+  print('  ' + '\n  '.join([line for line in configure.split('\n') if 'CPM:' in line]))
+  build = runCommand('cmake --build %s -j%i' % (project, os.cpu_count()))
+  print('  ' + '\n  '.join([line for line in build.split('\n') if 'Built target' in line]))
+  print('')

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -22,7 +22,7 @@ CPMAddPackage(
 
 add_executable(CPMExampleCatch2 main.cpp)
 target_link_libraries(CPMExampleCatch2 fibonacci Catch2)
-set_target_properties(CPMExampleCatch2 PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleCatch2 PRIVATE cxx_std_17)
 
 # ---- Enable testing ----
 

--- a/examples/catch2/CMakeLists.txt
+++ b/examples/catch2/CMakeLists.txt
@@ -15,7 +15,7 @@ CPMAddPackage(
 CPMAddPackage(
   NAME Catch2
   GITHUB_REPOSITORY catchorg/Catch2
-  VERSION 2.5.0
+  VERSION 2.13.4
 )
 
 # ---- Create binary ----

--- a/examples/cereal/CMakeLists.txt
+++ b/examples/cereal/CMakeLists.txt
@@ -17,4 +17,4 @@ CPMAddPackage(
 
 add_executable(CPMExampleCereal main.cpp)
 target_link_libraries(CPMExampleCereal cereal)
-set_target_properties(CPMExampleCereal PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleCereal PRIVATE cxx_std_17)

--- a/examples/cereal/CMakeLists.txt
+++ b/examples/cereal/CMakeLists.txt
@@ -8,7 +8,7 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME cereal
-  VERSION 1.2.2
+  VERSION 1.3.0
   GITHUB_REPOSITORY USCiLab/cereal
   OPTIONS "SKIP_PORTABILITY_TEST ON" "JUST_INSTALL_CEREAL ON"
 )

--- a/examples/cxxopts/CMakeLists.txt
+++ b/examples/cxxopts/CMakeLists.txt
@@ -17,4 +17,4 @@ CPMAddPackage(
 
 add_executable(CPMExampleCXXOpts main.cpp)
 target_link_libraries(CPMExampleCXXOpts cxxopts)
-set_target_properties(CPMExampleCXXOpts PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleCXXOpts PRIVATE cxx_std_17)

--- a/examples/doctest/CMakeLists.txt
+++ b/examples/doctest/CMakeLists.txt
@@ -15,7 +15,7 @@ CPMAddPackage(
 CPMAddPackage(
   NAME doctest
   GITHUB_REPOSITORY onqtam/doctest
-  GIT_TAG 2.3.2
+  GIT_TAG 2.4.5
 )
 
 # ---- Create binary ----

--- a/examples/doctest/CMakeLists.txt
+++ b/examples/doctest/CMakeLists.txt
@@ -22,7 +22,7 @@ CPMAddPackage(
 
 add_executable(CPMExampleDoctest main.cpp)
 target_link_libraries(CPMExampleDoctest fibonacci doctest)
-set_target_properties(CPMExampleDoctest PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleDoctest PRIVATE cxx_std_17)
 
 # ---- Enable testing ----
 

--- a/examples/entt/CMakeLists.txt
+++ b/examples/entt/CMakeLists.txt
@@ -21,6 +21,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMEnTTExample "main.cpp")
+add_executable(CPMEnTTExample main.cpp)
 set_target_properties(CPMEnTTExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMEnTTExample EnTT)

--- a/examples/entt/CMakeLists.txt
+++ b/examples/entt/CMakeLists.txt
@@ -16,11 +16,11 @@ CPMAddPackage(
 
 if(EnTT_ADDED)
   add_library(EnTT INTERFACE)
-  target_include_directories(EnTT INTERFACE ${EnTT_SOURCE_DIR}/src)
+  target_include_directories(EnTT SYSTEM INTERFACE ${EnTT_SOURCE_DIR}/src)
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMEnTTExample main.cpp)
-set_target_properties(CPMEnTTExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMEnTTExample PRIVATE cxx_std_17)
 target_link_libraries(CPMEnTTExample EnTT)

--- a/examples/fmt/CMakeLists.txt
+++ b/examples/fmt/CMakeLists.txt
@@ -8,12 +8,12 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME fmt
-  GIT_TAG 6.1.2
+  GIT_TAG 7.1.3
   GITHUB_REPOSITORY fmtlib/fmt
 )
 
 # ---- Executable ----
 
-add_executable(CPMFmtExample "main.cpp")
+add_executable(CPMFmtExample main.cpp)
 set_target_properties(CPMFmtExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMFmtExample fmt)

--- a/examples/fmt/CMakeLists.txt
+++ b/examples/fmt/CMakeLists.txt
@@ -15,5 +15,5 @@ CPMAddPackage(
 # ---- Executable ----
 
 add_executable(CPMFmtExample main.cpp)
-set_target_properties(CPMFmtExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMFmtExample PRIVATE cxx_std_17)
 target_link_libraries(CPMFmtExample fmt)

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -24,7 +24,7 @@ CPMAddPackage(
 
 add_executable(CPMExampleGtest main.cpp)
 target_link_libraries(CPMExampleGtest fibonacci gtest gtest_main gmock)
-set_target_properties(CPMExampleGtest PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMExampleGtest PRIVATE cxx_std_17)
 
 # ---- Enable testing ----
 

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(CPMExampleGtest)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS NO)
+
 # ---- Dependencies ----
 
 include(../../cmake/CPM.cmake)

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(CPMExampleGtest)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS NO)
-
 # ---- Dependencies ----
 
 include(../../cmake/CPM.cmake)

--- a/examples/gtest/CMakeLists.txt
+++ b/examples/gtest/CMakeLists.txt
@@ -15,8 +15,8 @@ CPMAddPackage(
 CPMAddPackage(
   NAME googletest
   GITHUB_REPOSITORY google/googletest
-  GIT_TAG release-1.8.1
-  VERSION 1.8.1
+  GIT_TAG release-1.10.0
+  VERSION 1.10.0
   OPTIONS "INSTALL_GTEST OFF" "gtest_force_shared_crt"
 )
 

--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -8,10 +8,10 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME nlohmann_json
-  VERSION 3.6.1
+  VERSION 3.9.1
   # not using the repo as it takes forever to clone
-  URL https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip
-  URL_HASH SHA256=69cc88207ce91347ea530b227ff0776db82dcb8de6704e1a3d74f4841bc651cf
+  URL https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip
+  URL_HASH SHA256=6bea5877b1541d353bd77bdfbdb2696333ae5ed8f9e8cc22df657192218cad91
 )
 
 if(nlohmann_json_ADDED)
@@ -21,6 +21,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMJSONExample "main.cpp")
+add_executable(CPMJSONExample main.cpp)
 set_target_properties(CPMJSONExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMJSONExample nlohmann_json)

--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -16,11 +16,11 @@ CPMAddPackage(
 
 if(nlohmann_json_ADDED)
   add_library(nlohmann_json INTERFACE)
-  target_include_directories(nlohmann_json INTERFACE ${nlohmann_json_SOURCE_DIR})
+  target_include_directories(nlohmann_json SYSTEM INTERFACE ${nlohmann_json_SOURCE_DIR}/include)
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMJSONExample main.cpp)
-set_target_properties(CPMJSONExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMJSONExample PRIVATE cxx_std_17)
 target_link_libraries(CPMJSONExample nlohmann_json)

--- a/examples/linenoise/CMakeLists.txt
+++ b/examples/linenoise/CMakeLists.txt
@@ -14,11 +14,11 @@ CPMAddPackage(
 
 if(linenoise_ADDED)
   add_library(linenoise ${linenoise_SOURCE_DIR}/linenoise.c)
-  target_include_directories(linenoise PUBLIC ${linenoise_SOURCE_DIR})
+  target_include_directories(linenoise SYSTEM PUBLIC ${linenoise_SOURCE_DIR})
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMlinenoiseExample main.cpp)
-set_target_properties(CPMlinenoiseExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMlinenoiseExample PRIVATE cxx_std_17)
 target_link_libraries(CPMlinenoiseExample linenoise)

--- a/examples/linenoise/CMakeLists.txt
+++ b/examples/linenoise/CMakeLists.txt
@@ -19,6 +19,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMlinenoiseExample "main.cpp")
+add_executable(CPMlinenoiseExample main.cpp)
 set_target_properties(CPMlinenoiseExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMlinenoiseExample linenoise)

--- a/examples/range-v3/CMakeLists.txt
+++ b/examples/range-v3/CMakeLists.txt
@@ -16,11 +16,11 @@ CPMAddPackage(
 
 if(range-v3_ADDED)
   add_library(range-v3 INTERFACE IMPORTED)
-  target_include_directories(range-v3 INTERFACE "${range-v3_SOURCE_DIR}/include")
+  target_include_directories(range-v3 SYSTEM INTERFACE "${range-v3_SOURCE_DIR}/include")
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMRangev3Example main.cpp)
-set_target_properties(CPMRangev3Example PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMRangev3Example PRIVATE cxx_std_17)
 target_link_libraries(CPMRangev3Example range-v3)

--- a/examples/range-v3/CMakeLists.txt
+++ b/examples/range-v3/CMakeLists.txt
@@ -8,8 +8,8 @@ include(../../cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME range-v3
-  URL https://github.com/ericniebler/range-v3/archive/0.5.0.zip
-  VERSION 0.5.0
+  URL https://github.com/ericniebler/range-v3/archive/0.11.0.zip
+  VERSION 0.11.0
   # the range-v3 CMakeLists screws with configuration options
   DOWNLOAD_ONLY True
 )
@@ -21,6 +21,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMRangev3Example "main.cpp")
+add_executable(CPMRangev3Example main.cpp)
 set_target_properties(CPMRangev3Example PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMRangev3Example range-v3)

--- a/examples/simple_match/CMakeLists.txt
+++ b/examples/simple_match/CMakeLists.txt
@@ -20,6 +20,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMSimpleMatchExample "main.cpp")
+add_executable(CPMSimpleMatchExample main.cpp)
 set_target_properties(CPMSimpleMatchExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMSimpleMatchExample simple_match)

--- a/examples/simple_match/CMakeLists.txt
+++ b/examples/simple_match/CMakeLists.txt
@@ -15,11 +15,11 @@ CPMAddPackage(
 
 if(simple_match_ADDED)
   add_library(simple_match INTERFACE IMPORTED)
-  target_include_directories(simple_match INTERFACE "${simple_match_SOURCE_DIR}/include")
+  target_include_directories(simple_match SYSTEM INTERFACE "${simple_match_SOURCE_DIR}/include")
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMSimpleMatchExample main.cpp)
-set_target_properties(CPMSimpleMatchExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMSimpleMatchExample PRIVATE cxx_std_17)
 target_link_libraries(CPMSimpleMatchExample simple_match)

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -20,7 +20,7 @@ if(lua_ADDED)
   list(REMOVE_ITEM lua_sources "${lua_SOURCE_DIR}/lua.c" "${lua_SOURCE_DIR}/luac.c")
   add_library(lua STATIC ${lua_sources})
 
-  target_include_directories(lua PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
+  target_include_directories(lua SYSTEM PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
 endif()
 
 CPMAddPackage(
@@ -32,12 +32,12 @@ CPMAddPackage(
 
 if(sol2_ADDED)
   add_library(sol2 INTERFACE IMPORTED)
-  target_include_directories(sol2 INTERFACE ${sol2_SOURCE_DIR}/include)
+  target_include_directories(sol2 SYSTEM INTERFACE ${sol2_SOURCE_DIR}/include)
   target_link_libraries(sol2 INTERFACE lua)
 endif()
 
 # ---- Executable ----
 
 add_executable(CPMSol2Example main.cpp)
-set_target_properties(CPMSol2Example PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMSol2Example PRIVATE cxx_std_17)
 target_link_libraries(CPMSol2Example sol2)

--- a/examples/sol2/CMakeLists.txt
+++ b/examples/sol2/CMakeLists.txt
@@ -38,6 +38,6 @@ endif()
 
 # ---- Executable ----
 
-add_executable(CPMSol2Example "main.cpp")
+add_executable(CPMSol2Example main.cpp)
 set_target_properties(CPMSol2Example PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMSol2Example sol2)

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -15,5 +15,5 @@ CPMAddPackage(
 # ---- Executable ----
 
 add_executable(CPMSpdlogExample main.cpp)
-set_target_properties(CPMSpdlogExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMSpdlogExample PRIVATE cxx_std_17)
 target_link_libraries(CPMSpdlogExample spdlog)

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -9,11 +9,11 @@ include(../../cmake/CPM.cmake)
 CPMAddPackage(
   NAME spdlog
   GITHUB_REPOSITORY gabime/spdlog
-  VERSION 1.7.0
+  VERSION 1.8.2
 )
 
 # ---- Executable ----
 
-add_executable(CPMSpdlogExample "main.cpp")
+add_executable(CPMSpdlogExample main.cpp)
 set_target_properties(CPMSpdlogExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMSpdlogExample spdlog)

--- a/examples/yaml/CMakeLists.txt
+++ b/examples/yaml/CMakeLists.txt
@@ -17,5 +17,5 @@ CPMAddPackage(
 # ---- Executable ----
 
 add_executable(CPMYamlExample main.cpp)
-set_target_properties(CPMYamlExample PROPERTIES CXX_STANDARD 17)
+target_compile_features(CPMYamlExample PRIVATE cxx_std_17)
 target_link_libraries(CPMYamlExample yaml-cpp)

--- a/examples/yaml/CMakeLists.txt
+++ b/examples/yaml/CMakeLists.txt
@@ -9,15 +9,13 @@ include(../../cmake/CPM.cmake)
 CPMAddPackage(
   NAME yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-  # 0.6.2 uses deprecated CMake syntax
   VERSION 0.6.3
-  # 0.6.3 is not released yet, so use the most recent commit
-  GIT_TAG 012269756149ae99745b6dafefd415843d7420bb
+  GIT_TAG yaml-cpp-0.6.3
   OPTIONS "YAML_CPP_BUILD_TESTS Off" "YAML_CPP_BUILD_CONTRIB Off" "YAML_CPP_BUILD_TOOLS Off"
 )
 
 # ---- Executable ----
 
-add_executable(CPMYamlExample "main.cpp")
+add_executable(CPMYamlExample main.cpp)
 set_target_properties(CPMYamlExample PROPERTIES CXX_STANDARD 17)
 target_link_libraries(CPMYamlExample yaml-cpp)


### PR DESCRIPTION
fix  examples with build problems too

see https://github.com/TheLartians/CPM.cmake/issues/189

add `cmake project code injection` as an option when using `build_all.py`

see https://cmake.org/cmake/help/latest/command/project.html#code-injection

tested with Apple clang version 12.0.0 (clang-1200.0.32.29)