### PR TITLE
fix superbuild cmake < 3.17

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -136,7 +136,10 @@ include(CMakeParseArguments)
 
 # Initialize logging prefix
 if(NOT CPM_INDENT)
-  set(CPM_INDENT "CPM:" CACHE INTERNAL "")
+  set(CPM_INDENT
+      "CPM:"
+      CACHE INTERNAL ""
+  )
 endif()
 
 function(cpm_find_package NAME VERSION)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -133,7 +133,7 @@ include(CMakeParseArguments)
 
 # Initialize logging prefix
 if(NOT CPM_INDENT)
-  set(CPM_INDENT "CPM:")
+  set(CPM_INDENT "CPM:" CACHE INTERNAL "")
 endif()
 
 function(cpm_find_package NAME VERSION)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -41,6 +41,9 @@ It is recommended to upgrade CPM to the most recent version. \
 See https://github.com/TheLartians/CPM.cmake for more information."
       )
     endif()
+    if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+      include(FetchContent)
+    endif()
     return()
   endif()
 


### PR DESCRIPTION
issue: #192 

* CPM_INDENT (first commit) :
I agree with you. set(CPM_INDENT "CPM:" CACHE INTERNAL "") seems to be appropriate.

* include(FetchContent):
Since the problem only occurs when using cmake < 3.17, I suggest to check the current cmake version and call `include(FetchContent)` for each `include(CPM.cmake)` when necessary.

During a future upgrade of the minimal cmake version, this can be noticed and removed easily.